### PR TITLE
Fix Backup Disabling

### DIFF
--- a/charts/unifi-controller/templates/deployment.yaml
+++ b/charts/unifi-controller/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}           
-        {{- if .Values.persistence.backup }}
+        {{- if .Values.persistence.backup.enabled }}
         - name: backup-data
           persistentVolumeClaim:
             claimName: {{ include "unifi.fullname" . }}-backup


### PR DESCRIPTION
When disabling the backup functionality (persistence.backup.enabled: false), the deployment still tried to attach the backup volume because the conditional in its template only checked for the existence of persistence.backup, not for the state of its enabled flag.