### PR TITLE
[UniFi] Add support for a service type

### DIFF
--- a/charts/unifi-controller/Chart.yaml
+++ b/charts/unifi-controller/Chart.yaml
@@ -3,7 +3,7 @@ name: unifi-controller
 description: A Helm Chart for deploying a UniFi controller to Kubernetes
 icon: https://assets-global.website-files.com/622b70d8906c7ab0c03f77f8/63b40a92093c6b2f3767e4e6_tMCv8T-y_400x400.png
 type: application
-version: 2.1.1
+version: 2.1.2
 keywords:
   - unifi
   - controller 

--- a/charts/unifi-controller/Chart.yaml
+++ b/charts/unifi-controller/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
     url: https://qonstrukt.nl
 annotations:
   artifacthub.io/changes: |
-    - Upgrade Controller to v7.4.162
+    - Add support for a service type
   artifacthub.io/images: |
     - name: unifi-controller
       image: linuxserver/unifi-controller:7.4.162

--- a/charts/unifi-controller/templates/service.yaml
+++ b/charts/unifi-controller/templates/service.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: LoadBalancer
+  type: {{ .Values.service.type }}
   ports: 
   - port: {{ .Values.service.ports.devicecom }}
     targetPort: 8080 


### PR DESCRIPTION
# Helm Chart Service Type

## Summary

This PR adds a new `service.type` value to the Helm chart. This value can be used to specify the type of service to be used for the `service` resource in the Helm chart.

## Motivation

The current Helm chart uses a `service.type` value of `LoadBalancer` for the `service` resource. This is not always desirable, as it requires the cluster to have a load balancer available. This is not always the case, for example when using a local Kubernetes cluster such as Minikube or k3s.

