### PR TITLE
Add loadBalancerIP Configuration to Helm Chart

### DIFF
--- a/charts/unifi-controller/Chart.yaml
+++ b/charts/unifi-controller/Chart.yaml
@@ -3,7 +3,7 @@ name: unifi-controller
 description: A Helm Chart for deploying a UniFi controller to Kubernetes
 icon: https://assets-global.website-files.com/622b70d8906c7ab0c03f77f8/63b40a92093c6b2f3767e4e6_tMCv8T-y_400x400.png
 type: application
-version: 2.5.0
+version: 2.5.1
 keywords:
   - unifi
   - controller 

--- a/charts/unifi-controller/templates/service.yaml
+++ b/charts/unifi-controller/templates/service.yaml
@@ -72,4 +72,6 @@ spec:
   {{- end }}
   selector:
     {{- include "unifi.selectorLabels" . | nindent 4 }}
-
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}

--- a/charts/unifi-controller/values.yaml
+++ b/charts/unifi-controller/values.yaml
@@ -30,6 +30,7 @@ service:
     webapi: 8443
   appDiscovery: false
   syslogCapture: false
+  loadBalancerIP: "192.168.0.0"
 
 ingress:
   enabled: true

--- a/charts/unifi-controller/values.yaml
+++ b/charts/unifi-controller/values.yaml
@@ -30,7 +30,7 @@ service:
     webapi: 8443
   appDiscovery: false
   syslogCapture: false
-  loadBalancerIP: "192.168.0.0"
+  loadBalancerIP: ""
 
 ingress:
   enabled: true


### PR DESCRIPTION
## Overview

This PR introduces the ability to specify a `loadBalancerIP` in our Helm Chart, catering to environments where MetalLB is not set for automatic IP assignment.

## Rationale

In setups where MetalLB lacks auto-assignment, specifying a fixed IP for the Load Balancer is necessary. This update enhances our Helm Chart's flexibility and compatibility in diverse network configurations.

## Testing

- Deployed the updated Helm Chart in an environment with MetalLB in non-autoassign mode.
- Set `loadBalancerIP` in values.yaml and confirmed the correct assignment to the Load Balancer service.
- Ensured no impact on environments with autoassign-enabled MetalLB.

## Changes

- [x] New feature (non-breaking change which adds functionality)
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

## Additional Notes

Open for feedback and further discussion.

---

Thank you for reviewing this PR. Looking forward to any comments or suggestions for improvement.
