### PR TITLE
[Unifi] Add priority class name

### DIFF
--- a/charts/unifi-controller/Chart.yaml
+++ b/charts/unifi-controller/Chart.yaml
@@ -3,7 +3,7 @@ name: unifi-controller
 description: A Helm Chart for deploying a UniFi controller to Kubernetes
 icon: https://assets-global.website-files.com/622b70d8906c7ab0c03f77f8/63b40a92093c6b2f3767e4e6_tMCv8T-y_400x400.png
 type: application
-version: 2.6.1
+version: 2.6.2
 keywords:
   - unifi
   - controller 
@@ -16,7 +16,7 @@ maintainers:
     url: https://qonstrukt.nl
 annotations:
   artifacthub.io/changes: |
-    - Add loadBalancerIP Configuration support
+    - Add priority class name support
   artifacthub.io/images: |
     - name: unifi-controller
       image: linuxserver/unifi-controller:8.0.24

--- a/charts/unifi-controller/templates/deployment.yaml
+++ b/charts/unifi-controller/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         {{- include "unifi.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/unifi-controller/values.yaml
+++ b/charts/unifi-controller/values.yaml
@@ -9,6 +9,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+priorityClassName: ""
+
 serviceAccount:
   create: true
   annotations: {}


### PR DESCRIPTION
Adds the ability to set a priority class name on the Unifi Controller deployment. This can be used to ensure this pod will never be evicted from a node to make room for another.